### PR TITLE
Log device Info on index start

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import logger from './services/logger'
 import { Listener } from './services/listener'
 import { ListenerBaileys } from './services/listener_baileys'
 
-import { BASE_URL, PORT } from './defaults'
+import { BASE_URL, PORT, CONFIG_SESSION_PHONE_CLIENT, CONFIG_SESSION_PHONE_NAME } from './defaults'
 
 const outgoingCloudApi: Outgoing = new OutgoingCloudApi(getConfigByEnv)
 
@@ -30,7 +30,7 @@ const sessionStore: SessionStore = new SessionStoreFile()
 const app: App = new App(incomingBaileys, outgoingCloudApi, BASE_URL, getConfigByEnv, sessionStore, onNewLoginn)
 
 app.server.listen(PORT, '0.0.0.0', async () => {
-  logger.info('Unoapi Cloud version: %s, listening on port: %s', version, PORT)
+  logger.info('Unoapi Cloud version: %s, listening on port: %s | Linked Device: %s(%s)', version, PORT, CONFIG_SESSION_PHONE_CLIENT, CONFIG_SESSION_PHONE_NAME)
   autoConnect(sessionStore, incomingBaileys, listenerBaileys, getConfigByEnv, getClientBaileys, onNewLoginn)
 })
 


### PR DESCRIPTION
Log device Info on index start, to have the same information when the API is started on files mode.