### PR TITLE
add env message to check phone

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ CONFIG_SESSION_PHONE_CLIENT=Unoapi Name that will be displayed on smartphone con
 CONFIG_SESSION_PHONE_NAME=Chrome Browser Name = Chrome | Firefox | Edge | Opera | Safari
 WHATSAPP_VERSION=Version of whatsapp, default is [2, 2413, 1]
 CONSUMER_TIMEOUT_MS=miliseconds in timeout for consume job, default is 30000
+MESSAGE_CHECK_WAAPP=message to send webwook when uno fails on reading contente. default '🕒 Não foi possível ler a mensagem. Peça para enviar novamente ou abra o Whatsapp no celular.'
 ```
 
 Bucket env to config assets media compatible with S3, this config can't save in redis:

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -109,6 +109,7 @@ export const VALIDATE_ROUTING_KEY = process.env.VALIDATE_ROUTING_KEY === _undefi
 export const CONFIG_SESSION_PHONE_CLIENT = process.env.CONFIG_SESSION_PHONE_CLIENT || 'Unoapi'
 export const CONFIG_SESSION_PHONE_NAME = process.env.CONFIG_SESSION_PHONE_NAME || 'Chrome'
 export const WHATSAPP_VERSION = JSON.parse(process.env.WHATSAPP_VERSION || '[2, 3000, 101590130]') as WAVersion
+export const MESSAGE_CHECK_WAAPP = process.env.MESSAGE_CHECK_WAAPP || '🕒 Não foi possível ler a mensagem. Peça para enviar novamente ou abra o Whatsapp no celular.'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const STORAGE_OPTIONS = (storage: any) => {

--- a/src/services/transformer.ts
+++ b/src/services/transformer.ts
@@ -4,6 +4,7 @@ import { parsePhoneNumber } from 'awesome-phonenumber'
 import vCard from 'vcf'
 import logger from './logger'
 import { Config } from './config'
+import { MESSAGE_CHECK_WAAPP } from '../defaults'
 
 export const TYPE_MESSAGES_TO_PROCESS_FILE = ['imageMessage', 'videoMessage', 'audioMessage', 'documentMessage', 'stickerMessage']
 
@@ -565,7 +566,7 @@ export const fromBaileysMessageContent = (phone: string, payload: any, config?: 
             payload.messageStubParameters[0] &&
             MESSAGE_STUB_TYPE_ERRORS.includes(payload.messageStubParameters[0].toLowerCase())) {
           message.text = {
-            body: '🕒 Não foi possível ler a mensagem. Peça para enviar novamente ou abra o Whatsapp no celular.',
+            body: MESSAGE_CHECK_WAAPP,
           }
           message.type = 'text'
           change.value.messages.push(message)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a default error message for message reading failures, enhancing user feedback.

- **Documentation**
	- Updated the README.md to include the new configuration variable `MESSAGE_CHECK_WAAPP` with its default value.

- **Refactor**
	- Centralized the error message handling by replacing hardcoded messages with the new constant `MESSAGE_CHECK_WAAPP`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->