### PR TITLE
Fix Log for WAWeb version and default version

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,4 +1,4 @@
-import { WAVersion } from "@whiskeysockets/baileys"
+import { WAVersion, DEFAULT_CONNECTION_CONFIG } from "@whiskeysockets/baileys"
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _undefined: any = undefined
@@ -108,7 +108,7 @@ export const CLEAN_CONFIG_ON_DISCONNECT =
 export const VALIDATE_ROUTING_KEY = process.env.VALIDATE_ROUTING_KEY === _undefined ? false : process.env.VALIDATE_ROUTING_KEY == 'true'
 export const CONFIG_SESSION_PHONE_CLIENT = process.env.CONFIG_SESSION_PHONE_CLIENT || 'Unoapi'
 export const CONFIG_SESSION_PHONE_NAME = process.env.CONFIG_SESSION_PHONE_NAME || 'Chrome'
-export const WHATSAPP_VERSION = JSON.parse(process.env.WHATSAPP_VERSION || '[2, 3000, 101590130]') as WAVersion
+export const WHATSAPP_VERSION = JSON.parse(process.env.WHATSAPP_VERSION || `[${DEFAULT_CONNECTION_CONFIG.version}]`) as WAVersion
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const STORAGE_OPTIONS = (storage: any) => {

--- a/src/services/socket.ts
+++ b/src/services/socket.ts
@@ -156,7 +156,7 @@ export const connect = async ({
     await setSessionStatus(phone, 'online')
     logger.info(`${phone} connected`)
     const { version, isLatest } = await fetchLatestBaileysVersion()
-    const message = `Connected with ${phone} using Whatsapp Version v${version.join('.')}, is latest? ${isLatest} at ${new Date().toUTCString()}`
+    const message = `Connected with ${phone} using Whatsapp Version v${WHATSAPP_VERSION.join('.')}, latest Baileys version is v${version.join('.')} at ${new Date().toUTCString()}`
     await onNotification(message, false)
   }
 


### PR DESCRIPTION
Fix Log for WAWeb version and Change and Default WAWeb version to default baileys version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configurability of the WhatsApp version to reflect the latest connection configuration dynamically.
  
- **Bug Fixes**
	- Improved clarity of log messages to distinguish between the connected device's WhatsApp version and the latest Baileys library version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->