### PR TITLE
set hello as only template

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ CONFIG_SESSION_PHONE_NAME=Chrome Browser Name = Chrome | Firefox | Edge | Opera 
 WHATSAPP_VERSION=Version of whatsapp, default to local Baileys version.
 CONSUMER_TIMEOUT_MS=miliseconds in timeout for consume job, default is 30000
 MESSAGE_CHECK_WAAPP=message to send webwook when uno fails on reading content. default '🕒 Não foi possível ler a mensagem. Peça para enviar novamente ou abra o Whatsapp no celular.'
+ONLY_HELLO_TEMPLATE=true sets hello template as the only default template, default false.
 ```
 
 Bucket env to config assets media compatible with S3, this config can't save in redis:
@@ -401,7 +402,9 @@ http://localhost:9876/v15.0/phone_numbers \
 
 ## Templates
 
-The templates will be customized, saving in `${BASE_STORE}/${PHONE_NUMBER}/templates.json` , or when use redis with key `unoapi-template:${PHONE_NUMBER}`. The json format is:
+UnoAPI's default definition has 4 templates: hello, unoapi-bulk-report, unoapi-webhook and unoapi-config. UnoAPI can be configured to only present the hello template as default, check the ONLY_HELLO_TEMPLATE variable to obtain this behavior
+
+The templates for each Session (PHONE_NUMBER) can be be customized, saving in `${BASE_STORE}/${PHONE_NUMBER}/templates.json` , or when use redis with key `unoapi-template:${PHONE_NUMBER}`. The json format is:
 
 ```json
 [

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -112,6 +112,7 @@ export const CONFIG_SESSION_PHONE_NAME = process.env.CONFIG_SESSION_PHONE_NAME |
 export const MESSAGE_CHECK_WAAPP = process.env.MESSAGE_CHECK_WAAPP || '🕒 Não foi possível ler a mensagem. Peça para enviar novamente ou abra o Whatsapp no celular.'
 export const WHATSAPP_VERSION = JSON.parse(process.env.WHATSAPP_VERSION || `[${DEFAULT_CONNECTION_CONFIG.version}]`) as WAVersion
 export const WAVOIP_TOKEN = process.env.WAVOIP_TOKEN || ''
+export const ONLY_HELLO_TEMPLATE: boolean = process.env.ONLY_HELLO_TEMPLATE === _undefined ? false : process.env.ONLY_HELLO_TEMPLATE == 'true'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const STORAGE_OPTIONS = (storage: any) => {


### PR DESCRIPTION
Add's the ability to set hello as the only default template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced README.md with new sections on templates, configuration options, webhook events, error messages, installation instructions, and legal notices.
	- Added detailed explanations of the `ONLY_HELLO_TEMPLATE` environment variable and its impact on template usage.
	- Updated examples section with Docker Compose configurations.

- **New Features**
	- Introduced the `ONLY_HELLO_TEMPLATE` configuration option for granular control over message templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->