### PR TITLE
Fix/Handling of webhooks configs to support multiple webhooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ data/medias/*
 data/stores/*
 data/sessions/*
 ./.env
+docker-compose-uno-dev.yml

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -19,7 +19,7 @@ export const WEBHOOK_TOKEN = process.env.WEBHOOK_TOKEN || '123abc'
 export const WEBHOOK_TIMEOUT_MS = parseInt(process.env.WEBHOOK_TIMEOUT_MS || '5000')
 export const CONSUMER_TIMEOUT_MS = parseInt(process.env.CONSUMER_TIMEOUT_MS || '30000')
 export const WEBHOOK_SEND_NEW_MESSAGES = process.env.WEBHOOK_SEND_NEW_MESSAGES == _undefined ? false : process.env.WEBHOOK_SEND_NEW_MESSAGES == 'true'
-export const WEBHOOK_SEND_GROUP_MESSAGES = process.env.WEBHOOK_SEND_GROUP_MESSAGES == _undefined ? false : process.env.WEBHOOK_SEND_GROUP_MESSAGES == 'true'
+export const WEBHOOK_SEND_GROUP_MESSAGES = process.env.WEBHOOK_SEND_GROUP_MESSAGES == _undefined ? true : process.env.WEBHOOK_SEND_GROUP_MESSAGES == 'true'
 export const WEBHOOK_SESSION = process.env.WEBHOOK_SESSION || ''
 export const AMQP_URL = process.env.AMQP_URL || 'amqp://guest:guest@localhost:5672'
 export const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379'

--- a/src/services/config_redis.ts
+++ b/src/services/config_redis.ts
@@ -11,14 +11,15 @@ export const getConfigRedis: getConfig = async (phone: string): Promise<Config> 
     const configRedis: any = { ...((await getConfigCache(phone)) || {}) }
     logger.info('Retrieve config default for %s', phone)
     const config: Config = { ...(await getConfigByEnv(phone)) }
-    
+
     if (configRedis) {
       Object.keys(configRedis).forEach((key) => {
         if (key === 'webhooks') {
-          const webhooksConfig = configRedis[key][0];
-          Object.keys(webhooksConfig).forEach((keyWebhook) => {
-            logger.debug('Override webhook env config by redis webhook config in %s: %s => %s', phone, keyWebhook, JSON.stringify(webhooksConfig[keyWebhook]));
-            config[keyWebhook] = webhooksConfig[keyWebhook];
+          configRedis[key].forEach((webhookConfig) => {
+            Object.keys(webhookConfig).forEach((keyWebhook) => {
+              logger.debug('Override webhook env config by redis webhook config in %s: %s => %s', phone, keyWebhook, JSON.stringify(webhookConfig[keyWebhook]));
+              config[keyWebhook] = webhookConfig[keyWebhook];
+            });
           });
         } else {
           logger.debug('Override env config by redis config in %s: %s => %s', phone, key, JSON.stringify(configRedis[key]));


### PR DESCRIPTION
Fix handling of webhooks configs to support multiple webhooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Default behavior for sending group messages via webhook has been changed to "send" when no specific environment variable is defined.

- **Bug Fixes**
	- Enhanced processing of webhook configurations for improved clarity and functionality.

- **Chores**
	- Updated version control settings to ignore the `.env` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->