### PR TITLE
scripts for generate unoapi and chatwoot stacks and server enviroment

### DIFF
--- a/examples/scripts/apps-model.yaml
+++ b/examples/scripts/apps-model.yaml
@@ -1,0 +1,154 @@
+version: "3.7"
+
+services:
+
+## --------------------------- REDIS --------------------------- ##
+  redis:
+    image: redis:latest
+    command: [
+        "redis-server",
+        "--appendonly",
+        "yes",
+        "--port",
+        "6379",
+        "--requirepass",
+        "${REDIS_PASS}"
+      ]
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASS}
+    volumes:
+      - redis_data:/data
+    networks:
+      - ${DOCKERNETWORK}
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: 512M
+
+##REDIS COMANDER - WEB PANEL
+  redisWeb:
+    image: ghcr.io/joeferner/redis-commander:latest
+    restart: always
+    networks:
+      - ${DOCKERNETWORK}
+    environment:
+      PORT: 8082
+      HTTP_USER: ${REDIS_USER}
+      REDIS_HOST: redis
+      REDIS_PASSWORD: ${REDIS_PASS}
+      HTTP_PASSWORD: ${REDIS_PASS}
+    depends_on:
+      - redis
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.redisdash.rule=Host(`${REDIS_SUBDOMAIN}`)
+      - traefik.http.routers.redisdash.entrypoints=web,websecure
+      - traefik.http.services.redisdash.loadbalancer.server.port=8082
+      - traefik.http.routers.redisdash.service=redisdash
+      - traefik.http.routers.redisdash.tls.certresolver=letsencryptresolver
+    deploy:
+      resources:
+        limits:
+          cpus: '1.00'
+          memory: 512M
+        reservations:
+          cpus: '0.10'
+          memory: 128M
+
+## --------------------------- RABBITMQ --------------------------- ##
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    hostname: rabbitmq
+    volumes:
+      - rabbit_data:/var/lib/rabbitmq
+    restart: always
+    networks:
+      - ${DOCKERNETWORK}
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS}
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.rabbitmq.rule=Host(`${RABBITMQ_SUBDOMAIN}`)
+      - traefik.http.routers.rabbitmq.entrypoints=websecure
+      - traefik.http.routers.rabbitmq.tls.certresolver=letsencryptresolver
+      - traefik.http.routers.rabbitmq.priority=1
+      - traefik.http.routers.rabbitmq.service=rabbitmq
+      - traefik.http.services.rabbitmq.loadbalancer.server.port=15672 
+    deploy:
+      resources:
+        limits:
+          cpus: '1.00'
+          memory: 512M
+        reservations:
+          cpus: '0.50'
+          memory: 128M
+## --------------------------- MINIO --------------------------- ##
+  minio:
+    image: quay.io/minio/minio:latest
+    command: server /data --console-address ":9001"
+    networks:
+      - ${DOCKERNETWORK}
+    volumes:
+      - minio_data:/data
+    restart: always
+    environment:
+      - MINIO_ROOT_USER=${MINIO_USER}
+      - MINIO_ROOT_PASSWORD=${MINIO_PASS}
+      - MINIO_BROWSER_REDIRECT_URL=https://${MINIOAPI_SUBDOMAIN}
+      - MINIO_SERVER_URL=https://${MINIOWEB_SUBDOMAIN}
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 256M
+        reservations:
+          cpus: '0.10'
+          memory: 128M
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.minio_public.rule=Host(`${MINIOWEB_SUBDOMAIN}`)
+      - traefik.http.routers.minio_public.entrypoints=web,websecure
+      - traefik.http.routers.minio_public.tls.certresolver=letsencryptresolver
+      - traefik.http.services.minio_public.loadbalancer.server.port=9000
+      - traefik.http.routers.minio_public.service=minio_public
+      - traefik.http.routers.minio_console.rule=Host(`${MINIOAPI_SUBDOMAIN}`)
+      - traefik.http.routers.minio_console.entrypoints=web,websecure
+      - traefik.http.routers.minio_console.tls.certresolver=letsencryptresolver
+      - traefik.http.services.minio_console.loadbalancer.server.port=9001
+      - traefik.http.routers.minio_console.service=minio_console
+
+## --------------------------- POSTGRES --------------------------- ##
+
+  postgres:
+    image: postgres:17-alpine
+    volumes:
+      - postgres:/data/postgres
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: md5
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASS}
+    restart: always
+    networks:
+      - ${DOCKERNETWORK}
+
+
+volumes:
+  #REDIS_VOLUME
+  redis_data:
+
+  #RABIT_VOLUME
+  rabbit_data:
+
+  #MINIO_VOLUME
+  minio_data:
+
+  #POSTGRES_VOLUME
+  postgres:
+
+networks:
+  ${DOCKERNETWORK}:
+    external: true
+    name: ${DOCKERNETWORK} 

--- a/examples/scripts/chatwoot-model.yaml
+++ b/examples/scripts/chatwoot-model.yaml
@@ -1,0 +1,90 @@
+version: '3.7'
+
+
+x-base: &base
+  image: ${CHATWOOT_IMAGE}
+  restart: 'no'
+  command: echo 'ok'
+  environment:
+    ENABLE_ACCOUNT_SIGNUP: false
+    REDIS_URL: redis://:${REDIS_PASS}@redis:6379
+    DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASS}@postgres:5432/${POSTGRES_DB}
+    ACTIVE_STORAGE_SERVICE: s3_compatible
+    STORAGE_BUCKET_NAME: ${CW_BUCKET}
+    STORAGE_ACCESS_KEY_ID: ${MINIO_ACCESS_KEY}
+    STORAGE_SECRET_ACCESS_KEY: ${MINIO_SECRET_KEY}
+    STORAGE_REGION: ${MINIO_REGION}
+    STORAGE_ENDPOINT: https://${MINIOAPI_SUBDOMAIN}
+    STORAGE_FORCE_PATH_STYLE: true
+    SECRET_KEY_BASE: ${SECRET_KEY_CW}
+    FRONTEND_URL: https://${CHATWOOT_SUBDOMAIN}
+    DEFAULT_LOCALE: 'pt_BR'
+    INSTALLATION_ENV: docker
+    NODE_ENV: production
+    RAILS_ENV: production
+    #MAILER_INBOUND_EMAIL_DOMAIN: 
+    #RAILS_INBOUND_EMAIL_SERVICE: 
+    #SMTP_ADDRESS: 
+    #SMTP_PASSWORD: 
+    #SMTP_PORT: 
+    #SMTP_USERNAME: 
+    #SMTP_AUTHENTICATION: 
+    #SMTP_ENABLE_STARTTLS_AUTO: 
+    RAILS_MASTER_KEY: ${SECRET_KEY_CW}
+    WEB_CONCURRENCY: 5
+    RAILS_MAX_THREADS: 5
+    SIDEKIQ_CONCURRENCY: 5
+    LOG_LEVEL: info
+    UNOAPI_AUTH_TOKEN: ${UNOAPI_AUTH_TOKEN}
+    ENABLE_RACK_ATTACK: false
+    POSTGRES_STATEMENT_TIMEOUT: 600s
+    RACK_TIMEOUT_SERVICE_TIMEOUT: 600s
+services:
+  web:
+    <<: *base
+    command: ['bundle', 'exec', 'rails', 's', '-p', '3000', '-b', '0.0.0.0']
+    restart: always
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.chatwootweb.rule=Host(`${CHATWOOT_SUBDOMAIN}`)
+      - traefik.http.routers.chatwootweb.entrypoints=web,websecure
+      - traefik.http.services.chatwootweb.loadbalancer.server.port=3000
+      - traefik.http.routers.chatwootweb.service=chatwootweb
+      - traefik.http.routers.chatwootweb.tls.certresolver=letsencryptresolver
+    networks:
+      - ${DOCKERNETWORK}
+    deploy:
+      resources:
+        limits:
+          cpus: '3.00'
+          memory: 2048M
+        reservations:
+          cpus: '0.25'
+          memory: 512M
+
+  worker:
+    <<: *base
+    command: ['bundle', 'exec', 'sidekiq', '-C', 'config/sidekiq.yml']
+    restart: always
+    networks:
+      - ${DOCKERNETWORK}
+    deploy:
+      replicas: 1
+      resources:
+        limits:
+          cpus: '1.00'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 512M
+
+  migrate:
+    <<: *base
+    restart: 'no'
+    command: ['bundle', 'exec', 'rails', 'db:chatwoot_prepare']
+    networks:
+      - ${DOCKERNETWORK}
+
+networks:
+  ${DOCKERNETWORK}:
+    external: true

--- a/examples/scripts/docker-model.yaml
+++ b/examples/scripts/docker-model.yaml
@@ -1,0 +1,79 @@
+version: "3.7"
+
+services:
+
+## --------------------------- TRAEFIK --------------------------- ##
+  traefik:
+    image: traefik:v3.3.3
+    command:
+      - "--api.dashboard=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker.network=${DOCKERNETWORK}"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
+      - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
+      - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.web.transport.respondingTimeouts.idleTimeout=3600"
+      - "--certificatesresolvers.letsencryptresolver.acme.httpchallenge=true"
+      - "--certificatesresolvers.letsencryptresolver.acme.httpchallenge.entrypoint=web"
+      - "--certificatesresolvers.letsencryptresolver.acme.storage=/etc/traefik/letsencrypt/acme.json"
+      - "--certificatesresolvers.letsencryptresolver.acme.email=${LETSENCRYPT_MAIL}"
+      - "--log.level=DEBUG"
+      - "--log.format=common"
+      - "--log.filePath=/var/log/traefik/traefik.log"
+      - "--accesslog=true"
+      - "--accesslog.filepath=/var/log/traefik/access-log"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.middlewares.redirect-https.redirectscheme.scheme=https"
+      - "traefik.http.middlewares.redirect-https.redirectscheme.permanent=true"
+      - "traefik.http.routers.http-catchall.rule=HostRegexp(`{host:.+}`)"
+      - "traefik.http.routers.http-catchall.entrypoints=web"
+      - "traefik.http.routers.http-catchall.middlewares=redirect-https"
+      - "traefik.http.routers.http-catchall.priority=1"
+    volumes:
+      - "certsVolume:/etc/traefik/letsencrypt"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      #- "/var/log/traefik:/var/log/traefik"
+    ports:
+      - "80:80"
+      - "443:443"
+    networks:
+      - ${DOCKERNETWORK}
+
+## --------------------------- PORTAINER --------------------------- ##
+  portainer:
+    image: portainer/portainer-ce:latest
+
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer_data:/data
+
+    networks:
+      - ${DOCKERNETWORK}
+    ports:
+      - 9000:9000
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.portainer.rule=Host(`${PORTAINER_SUBDOMAIN}`)"
+      - "traefik.http.services.portainer.loadbalancer.server.port=9000"
+      - "traefik.http.routers.portainer.tls.certresolver=letsencryptresolver"
+      - "traefik.http.routers.portainer.service=portainer"
+      - "traefik.docker.network=${DOCKERNETWORK}"
+      - "traefik.http.routers.portainer.entrypoints=websecure"
+      - "traefik.http.routers.portainer.priority=1"
+
+
+volumes:
+  #PORTAINER_VOLUME
+  portainer_data:
+
+  #TRAEFIK_VOLUME
+  certsVolume:
+
+networks:
+  ${DOCKERNETWORK}:
+    external: true
+    name: ${DOCKERNETWORK} 

--- a/examples/scripts/envSetup.sh
+++ b/examples/scripts/envSetup.sh
@@ -1,0 +1,345 @@
+#!/bin/bash
+
+# gerar aleatória
+generate_random_string() {
+    tr -dc A-Za-z0-9 </dev/urandom | head -c 20
+}
+
+# validar o domínio
+validate_domain() {
+    if echo "$1" | grep -qE '^[a-zA-Z0-9.-]+$'; then
+        return 0
+    else
+        echo "Domínio inválido. Deve conter apenas caracteres alfanuméricos, pontos e hífens."
+        return 1
+    fi
+}
+
+
+initialSetup(){
+    echo "Qual o nome da rede Docker padrão?"
+    read dockernetwork
+    dockernetwork=${dockernetwork:-"network"}
+
+
+    echo "Digite o email para os certificados: "
+    read letsencrypt_mail
+    letsencrypt_mail=${letsencrypt_mail:-"user@gmail.com"}
+
+    echo "Digite o domínio principal:"
+    read domain
+
+    # Validar domínio
+    while ! validate_domain "$domain"; do
+        echo "Digite um domínio válido:"
+        read domain
+    done
+
+    echo "Subdomínio do Portainer (padrão: portainer.$domain):"
+    read portainer_subdomain
+    portainer_subdomain=${portainer_subdomain:-"portainer.$domain"}
+
+    echo "Subdomínio do MinIO Console (padrão: console.minio.$domain):"
+    read minioweb_subdomain
+    minioweb_subdomain=${minioweb_subdomain:-"console.minio.$domain"}
+
+    echo "Subdomínio do MinIO API (padrão: api.minio.$domain):"
+    read minioapi_subdomain
+    minioapi_subdomain=${minioapi_subdomain:-"api.minio.$domain"}
+
+    echo "Subdomínio para o chatwoot (padrão: app.$domain):"
+    read chatwoot_subdomain
+    chatwoot_subdomain=${chatwoot_subdomain:-"app.$domain"}
+
+    echo "Subdomínio para o UnoAPI (padrão: unoapi.$domain):"
+    read unoapi_subdomain
+    unoapi_subdomain=${unoapi_subdomain:-"unoapi.$domain"}
+
+    echo "Subdomínio para o Redis (padrão: redis.$domain):"
+    read redis_subdomain
+    redis_subdomain=${redis_subdomain:-"redis.$domain"}
+
+    echo "Subdomínio para o RabbitMQ (padrão: rabbitmq.$domain):"
+    read rabbitmq_subdomain
+    rabbitmq_subdomain=${rabbitmq_subdomain:-"rabbitmq.$domain"}
+
+    echo "Usuário do PostgreSQL: (padrão: postgre)"
+    read postgres_user
+    postgres_user=${postgres_user:-"postgres"}
+    echo "Senha do PostgreSQL (deixe em branco para gerar automaticamente):"
+    read postgres_pass
+    postgres_pass=${postgres_pass:-$(generate_random_string)}
+
+    echo "Usuário do RabbitMQ (padrão: rabbitmq_user)"
+    read rabbitmq_user
+    rabbitmq_user=${rabbitmq_user:-"rabbitmq_user"}
+    echo "Senha do RabbitMQ (deixe em branco para gerar automaticamente):"
+    read rabbitmq_pass
+    rabbitmq_pass=${rabbitmq_pass:-$(generate_random_string)}
+
+    echo "Usuário do Redis (padrão: default):"
+    read redis_user
+    redis_user=${redis_user:-"default"}
+
+    echo "Senha do Redis (deixe em branco para gerar automaticamente):"
+    read redis_pass
+    redis_pass=${redis_pass:-$(generate_random_string)}
+
+    echo "Usuário do MinIO (padrão: minio_user) "
+    read minio_user
+    minio_user=${minio_user:-"minio_user"}
+    echo "Senha do MinIO (deixe em branco para gerar automaticamente):"
+    read minio_pass
+    minio_pass=${minio_pass:-$(generate_random_string)}
+
+    echo "Token de autenticação do UnoAPI (deixe em branco para gerar automaticamente):"
+    read unoapi_auth_token
+    unoapi_auth_token=${unoapi_auth_token:-$(generate_random_string)}
+
+    echo "Nome do Banco de Dados para o Chatwoot (padrão: chatwoot_db):"
+    read POSTGRES_DB
+    POSTGRES_DB=${POSTGRES_DB:-"chatwoot_db"}
+
+    # Confirmar se está OK
+    echo ""
+    echo "Por favor, revise as configurações:"
+    echo ""
+    echo "E-mail para os certificados: $letsencrypt_mail"
+    echo "Domínio: $domain"
+    echo "Subdomínio Portainer: $portainer_subdomain"
+    echo "Subdomínio Chatwoot: $chatwoot_subdomain"
+    echo "Subdomínio UnoAPI: $unoapi_subdomain"
+    echo "Subdomínio Redis: $redis_subdomain"
+    echo "Subdomínio RabbitMQ: $rabbitmq_subdomain"
+    echo "Usuário PostgreSQL: $postgres_user"
+    echo "Usuário RabbitMQ: $rabbitmq_user"
+    echo "Usuário Redis: $redis_user"
+    echo "Usuário MinIO: $minio_user"
+    echo "Token UnoAPI: $unoapi_auth_token"
+    echo "Subdomínio MinIO Console: $minioweb_subdomain"
+    echo "Subdomínio MinIO API: $minioapi_subdomain"
+    echo "Rede Docker: $dockernetwork"
+    echo ""
+    echo "Pressione 'y' para confirmar ou qualquer outra tecla para editar."
+
+    read confirm
+    if [ "$confirm" != "y" ]; then
+        echo ""
+        initialSetup
+        exit 0
+    fi
+
+    cat > .env <<EOL
+PORTAINER_SUBDOMAIN=$portainer_subdomain
+LETSENCRYPT_MAIL=$letsencrypt_mail
+DOMAIN=$domain
+CHATWOOT_SUBDOMAIN=$chatwoot_subdomain
+UNOAPI_SUBDOMAIN=$unoapi_subdomain
+REDIS_SUBDOMAIN=$redis_subdomain
+RABBITMQ_SUBDOMAIN=$rabbitmq_subdomain
+POSTGRES_USER=$postgres_user
+POSTGRES_PASS=$postgres_pass
+RABBITMQ_USER=$rabbitmq_user
+RABBITMQ_PASS=$rabbitmq_pass
+REDIS_USER=$redis_user
+REDIS_PASS=$redis_pass
+MINIO_USER=$minio_user
+MINIO_PASS=$minio_pass
+UNOAPI_AUTH_TOKEN=$unoapi_auth_token
+MINIOWEB_SUBDOMAIN=$minioweb_subdomain
+MINIOAPI_SUBDOMAIN=$minioapi_subdomain
+DOCKERNETWORK=$dockernetwork
+POSTGRES_DB=$POSTGRES_DB
+EOL
+
+    echo "Arquivo .env gerado com sucesso."
+
+    # Carregar as variáveis de ambiente do .env
+    export $(grep -v '^#' .env | xargs)
+
+    curl -fsSL https://raw.githubusercontent.com/clairton/unoapi-cloud/refs/heads/tutorials/examples/scripts/docker-model.yaml -o docker-model.yaml
+
+    envsubst < docker-model.yaml > docker-compose.yaml
+
+    curl -fsSL https://raw.githubusercontent.com/clairton/unoapi-cloud/refs/heads/tutorials/examples/scripts/apps-model.yaml -o apps-model.yaml
+
+    envsubst < apps-model.yaml > apps-compose.yaml
+
+    echo "Arquivo apps-compose.yaml gerado com sucesso."
+
+    echo ""
+    echo "Execute o comando docker compose up -d para iniciar os serviços!"
+    rm docker-model.yaml apps-model.yaml
+    setup
+    exit 0
+}
+
+minio_setup() {
+    echo "Iniciando a configuração do MinIO..."
+    echo "Digite a região configurada no MinIO:"
+    read MINIO_REGION
+    echo "Digite o nome do bucket para o UnoAPI:"
+    read UNOAPI_BUCKET
+    echo "Digite o Access Key do MinIO:"
+    read MINIO_ACCESS_KEY
+    echo "Digite o Secret Key do MinIO:"
+    read MINIO_SECRET_KEY
+    echo "Digite o nome do bucket para o Chatwoot:"
+    read CW_BUCKET
+
+    cat >> .env <<EOL
+MINIO_REGION=$MINIO_REGION
+UNOAPI_BUCKET=$UNOAPI_BUCKET
+MINIO_ACCESS_KEY=$MINIO_ACCESS_KEY
+MINIO_SECRET_KEY=$MINIO_SECRET_KEY
+CW_BUCKET=$CW_BUCKET
+EOL
+
+    echo "Variáveis adicionadas ao .env com sucesso."
+
+    setup
+    exit 0
+    
+}
+
+genUnoapiStack() {
+
+    REPO_OWNER="clairton"
+    REPO_NAME="unoapi-cloud"
+
+    # Obtém a última tag
+    LATEST_TAG=$(curl -s "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/tags" | jq -r '.[0].name' | cut -c2-)
+
+    # Verifica se encontrou uma tag
+    if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
+        echo "Nenhuma tag encontrada no repositório remoto."
+        exit 1
+    fi
+
+    echo "Você quer Gerar uma stack para a versão $LATEST_TAG da unoapi?"
+    echo "Para confirmar as versões disponíves, utilize este link: https://hub.docker.com/r/clairton/unoapi-cloud/tags
+
+    Se Deseja a versão $LATEST_TAG: Apenas tecle Enter, 
+    Caso Deseje outra Versão: Digite-a para utilizar"
+    read unoapi_version
+    unoapi_version=${unoapi_version:-$LATEST_TAG}
+
+    echo "Criando Stack para a Versão $unoapi_version da unoapi"
+
+    # Recarregar variáveis
+    export $(grep -v '^#' .env | xargs)
+    export UNOAPI_IMAGE="clairton/unoapi-cloud:$unoapi_version"
+
+    curl -fsSL https://raw.githubusercontent.com/clairton/unoapi-cloud/refs/heads/tutorials/examples/scripts/uno-model.yaml -o uno-model.yaml
+
+    envsubst < uno-model.yaml > docker-unoapi.yaml
+
+    echo "Arquivo docker-unoapi.yaml gerado com sucesso."
+    rm uno-model.yaml
+    setup
+    exit 0
+    
+}
+
+genCwStack() {
+    REPO_OWNER="clairton"
+    REPO_NAME="chatwoot"
+
+    # Obtém a última tag
+    LATEST_TAG=$(curl -s "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/tags" | jq -r '.[0].name')
+
+    # Verifica se encontrou uma tag
+    if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
+        echo "Nenhuma tag encontrada no repositório remoto."
+        exit 1
+    fi
+
+    echo "Você quer Gerar uma stack para a versão $LATEST_TAG do chatwoot uno?"
+    echo "Para confirmar as versões disponíves, utilize este link: https://hub.docker.com/r/clairton/chatwoot/tags
+
+    Se Deseja a versão $LATEST_TAG: Apenas tecle Enter, 
+    Caso Deseje outra Versão: Digite-a para utilizar"
+    read cw_version
+    cw_version=${cw_version:-$LATEST_TAG}
+
+    echo "Criando Stack para a Versão $cw_version do chatwoot uno"
+
+    # Recarregar variáveis
+    export $(grep -v '^#' .env | xargs)
+    export CHATWOOT_IMAGE="clairton/chatwoot:$cw_version"
+    export SECRET_KEY_CW=$(generate_random_string)
+
+    curl -fsSL https://raw.githubusercontent.com/clairton/unoapi-cloud/refs/heads/tutorials/examples/scripts/chatwoot-model.yaml -o chatwoot-model.yaml
+
+    envsubst < chatwoot-model.yaml > docker-chatwoot.yaml
+
+    echo "Arquivo docker-chatwoot.yaml gerado com sucesso."
+    rm chatwoot-model.yaml
+    
+    setup
+    exit 0
+}
+
+setup(){
+    # SETUP PRINCIPAL
+    if [ -f ".env" ]; then
+        echo "
+        Bem Vindo, Escolha uma opção
+        0 - Recriar .env
+        1 - Configurar as Opções para o Minio
+        2 - Gerar Stack Atualizada da Unoapi
+        3 - Gerar Stack Atualizada do Chatwoot Uno
+        9 - Sair"
+        read resposta
+
+        if [ "$resposta" = "1" ]; then
+            echo "Configurar Minio..."
+            minio_setup
+        fi
+        if [ "$resposta" = "2" ]; then
+            echo "Configurando Unoapi..."
+            genUnoapiStack
+        fi
+        if [ "$resposta" = "3" ]; then
+            echo "Configurado Chatwoot UNO..."
+            genCwStack
+        fi
+        if [ "$resposta" = "9" ]; then
+            echo "Saindo..."
+            exit 1
+        fi
+        if [ "$resposta" = "0" ]; then
+            echo "Setup Inicial..."
+            initialSetup
+        else
+            echo "Não compreendi sua resposta, Caso queira sair aperte CTRL + C
+            "
+            setup
+        fi
+        
+    else
+        echo "Bem vindo ao AutoConfigurar Stack para a Unoapi e Chatwoot UNO
+        Vamos começar?"
+        initialSetup
+        exit 0
+    fi
+}
+
+#Valida o parâmetro passado
+if [ "$1" = "minio" ]; then
+    minio_setup
+    exit 0
+fi
+if [ "$1" = "genUnoStack" ]; then
+    genUnoapiStack
+    exit 0
+fi
+
+if [ "$1" = "genCwStack" ]; then
+    genCwStack
+    exit 0
+fi
+if [ "$1" = "" ]; then
+    setup
+    exit 0
+fi

--- a/examples/scripts/serverSetup.sh
+++ b/examples/scripts/serverSetup.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+apt update && apt upgrade -y
+apt install -y ca-certificates curl gnupg wget jp lsb-release
+
+install -m 0755 -d /etc/apt/keyrings
+
+apt purge -y docker-* 
+
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    if [ "$ID" = "debian" ]; then
+
+        echo "Instalação em ambiente Debian"
+        curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/docker.gpg
+        chmod a+r /etc/apt/trusted.gpg.d/docker.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/trusted.gpg.d/docker.gpg] https://download.docker.com/linux/debian \
+        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+    elif [ "$ID" = "ubuntu" ]; then
+        echo "Instalação em ambiente UBUNTU"
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+        chmod a+r /etc/apt/keyrings/docker.asc
+        echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list
+    fi
+fi
+
+apt update && apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+
+echo "Digite o nome para a rede da sua instalação docker:"
+read dockerNetwork
+dockerNetwork=${dockerNetwork:-"network"}
+
+docker network create $dockerNetwork
+
+echo "Ambiente configurado com sucesso!"

--- a/examples/scripts/uno-model.yaml
+++ b/examples/scripts/uno-model.yaml
@@ -1,0 +1,50 @@
+x-base: &base
+  image: ${UNOAPI_IMAGE}
+  entrypoint: echo 'ok!'
+  networks:
+    - ${DOCKERNETWORK}
+  environment:
+    AMQP_URL: amqp://${RABBITMQ_USER}:${RABBITMQ_PASS}@rabbitmq:5672
+    REDIS_URL: redis://:${REDIS_PASS}@redis:6379
+    BASE_URL: https://${UNOAPI_SUBDOMAIN} #Dominio da Unoapi
+    STORAGE_ACCESS_KEY_ID: ${MINIO_ACCESS_KEY} #Access key do Bucket
+    STORAGE_SECRET_ACCESS_KEY: ${MINIO_SECRET_KEY} #Secret Key do Bucket
+    STORAGE_BUCKET_NAME: ${UNOAPI_BUCKET} #Nome do Bucket
+    STORAGE_ENDPOINT:	https://${MINIOAPI_SUBDOMAIN} #Domínio do Bucket
+    STORAGE_FORCE_PATH_STYLE: true #true para minio
+    STORAGE_REGION: ${MINIO_REGION} #Região do bucket
+    IGNORE_GROUP_MESSAGES: true #Ignorar Mensagem de Grupos -> true OU false
+    IGNORE_OWN_MESSAGES: false #Ignorar Mensagens Próprias de outros dispositivos, ex: App ou Web -> true OU false
+    UNOAPI_AUTH_TOKEN: ${UNOAPI_AUTH_TOKEN}
+    REJECT_CALLS: "" #Mensagem enviada ao Rejeitar Chamadas -> Vazio não rejeita as chamadas no app
+    REJECT_CALLS_WEBHOOK: "Ligação Recebida" #Aviso de ligação recebida no webhook
+    SEND_CONNECTION_STATUS: false #Receber status da conexãa -> true OU false
+    LOG_LEVEL: debug #Nível de log da api
+    UNO_LOG_LEVEL: debug #Nível do log da Unoapi
+    IGNORE_YOURSELF_MESSAGES: false #Ignorar suas mensagens de outros webhooks da uno -> true OU false
+  restart: 'no'
+
+services:
+  cloud:
+    <<: *base
+    entrypoint: yarn cloud
+    restart: always
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.unoapiweb.rule=Host(`${UNOAPI_SUBDOMAIN}`)
+      - traefik.http.routers.unoapiweb.entrypoints=web,websecure
+      - traefik.http.services.unoapiweb.loadbalancer.server.port=9876
+      - traefik.http.routers.unoapiweb.service=unoapiweb
+      - traefik.http.routers.unoapiweb.tls.certresolver=letsencryptresolver
+    deploy:
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 256M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
+
+networks:
+  ${DOCKERNETWORK}:
+    external: true


### PR DESCRIPTION
adding scripts to support the installation of unoapi and chatwoot.
with these scripts it is possible to configure the server and create the docker files to upload the standalone docker environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new container orchestration configurations to deploy backend services including caching, messaging, object storage, and databases.
  - Added a multi-component application setup featuring web interfaces, background processing, and migration routines.
  - Rolled out management and reverse proxy setups to enhance connectivity, routing, and secure access.

- **Chores**
  - Provided interactive setup scripts to streamline environment configuration and server provisioning for Docker deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->