### PR TITLE
Add webhook circuit breaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,7 +578,6 @@ The `.env` can be save one config, but on redis use different webhook by session
       "token": "kslflkhlkwq",
       "header": "api_access_token",
       "sendGroupMessages": false,
-      "sendGroupMessages": false,
       "sendNewMessages": false,
     }
   ],

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ WEBHOOK_URL_ABSOLUTE=the webhook absolute url, not use this if already use WEBHO
 WEBHOOK_URL=the webhook url, this config attribute put phone number on the end, no use if use WEBHOOK_URL_ABSOLUTE
 WEBHOOK_TOKEN=the webhook header token
 WEBHOOK_HEADER=the webhook header name
-WEBHOOK_TIMEOUT_MS=webhook request timeout, default 5000 ms
+WEBHOOK_TIMEOUT_MS=webhook request timeout, default 60000 ms
 WEBHOOK_CB_ENABLED=true enable webhook circuit breaker to avoid backlog when endpoint is offline, default true
 WEBHOOK_CB_FAILURE_THRESHOLD=number of failures within window to open circuit, default 1
 WEBHOOK_CB_OPEN_MS=how long to keep the circuit open (skip sends), default 120000
@@ -527,12 +527,22 @@ WEBHOOK_FORWARD_VERSION=the version of whatsapp cloud api, default is v17.0
 WEBHOOK_FORWARD_URL=the url of whatsapp cloud api, default is https://graph.facebook.com
 WEBHOOK_FORWARD_TIMEOUT_MS=the timeout for request to whatsapp cloud api, default is 360000
 ```
+Circuit breaker behavior:
+- Counts consecutive webhook failures within `WEBHOOK_CB_FAILURE_TTL_MS`.
+- When the count reaches `WEBHOOK_CB_FAILURE_THRESHOLD`, the circuit opens for `WEBHOOK_CB_OPEN_MS` and sends are skipped.
+- After the open window, delivery is attempted again automatically.
+
+Why keep `WEBHOOK_TIMEOUT_MS` low:
+- A high timeout blocks the consumer for too long when the endpoint is offline.
+- With lower timeout, failures are detected faster and the circuit opens sooner, reducing backlog.
+
 Example (circuit breaker):
 ```env
 WEBHOOK_CB_ENABLED=true
 WEBHOOK_CB_FAILURE_THRESHOLD=1
 WEBHOOK_CB_FAILURE_TTL_MS=300000
 WEBHOOK_CB_OPEN_MS=120000
+WEBHOOK_TIMEOUT_MS=60000
 ```
 
 ### Config session with redis

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Create a `.env`file and put configuration if you need change default value:
 This a general env:
 
 ```env
-CONSUMER_TIMEOUT_MS=miliseconds in timeout for consume job, default is 30000
+CONSUMER_TIMEOUT_MS=miliseconds in timeout for consume job, default is 15000
 AVAILABLE_LOCALES=default is `["en", "pt_BR", "pt"]`
 DEFAULT_LOCALE=locale for notifications status, now possibile is en, pt_BR and pt, default is en, to add new, use docker volume for exempla `/app/dist/src/locales/custom.json` and add `custom` in `AVAILABLE_LOCALES`
 ONLY_HELLO_TEMPLATE=true sets hello template as the only default template, default false.
@@ -526,7 +526,7 @@ WEBHOOK_FORWARD_BUSINESS_ACCOUNT_ID=the business account id of whatsapp cloud ap
 WEBHOOK_FORWARD_TOKEN=the token of whatsapp cloud api, default is empty
 WEBHOOK_FORWARD_VERSION=the version of whatsapp cloud api, default is v17.0
 WEBHOOK_FORWARD_URL=the url of whatsapp cloud api, default is https://graph.facebook.com
-WEBHOOK_FORWARD_TIMEOUT_MS=the timeout for request to whatsapp cloud api, default is 360000
+WEBHOOK_FORWARD_TIMEOUT_MS=the timeout for request to whatsapp cloud api, default is 60000
 ```
 Circuit breaker behavior:
 - Counts consecutive webhook failures within `WEBHOOK_CB_FAILURE_TTL_MS`.

--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ WEBHOOK_CB_FAILURE_THRESHOLD=number of failures within window to open circuit, d
 WEBHOOK_CB_OPEN_MS=how long to keep the circuit open (skip sends), default 120000
 WEBHOOK_CB_FAILURE_TTL_MS=failure counter window in ms, default 300000
 WEBHOOK_CB_REQUEUE_DELAY_MS=delay (ms) used to requeue when circuit is open, default 300000
+WEBHOOK_CB_LOCAL_CLEANUP_INTERVAL_MS=local CB map cleanup interval (ms), default 3600000
 WEBHOOK_SEND_NEW_MESSAGES=true, send new messages to webhook, caution with this, messages will be duplicated, default is false
 WEBHOOK_SEND_GROUP_MESSAGES=true, send group messages to webhook, default is true
 WEBHOOK_SEND_OUTGOING_MESSAGES=true, send outgoing messages to webhook, default is true
@@ -545,6 +546,7 @@ WEBHOOK_CB_FAILURE_THRESHOLD=1
 WEBHOOK_CB_FAILURE_TTL_MS=300000
 WEBHOOK_CB_OPEN_MS=120000
 WEBHOOK_CB_REQUEUE_DELAY_MS=300000
+WEBHOOK_CB_LOCAL_CLEANUP_INTERVAL_MS=3600000
 WEBHOOK_TIMEOUT_MS=60000
 ```
 

--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ WEBHOOK_CB_ENABLED=true enable webhook circuit breaker to avoid backlog when end
 WEBHOOK_CB_FAILURE_THRESHOLD=number of failures within window to open circuit, default 1
 WEBHOOK_CB_OPEN_MS=how long to keep the circuit open (skip sends), default 120000
 WEBHOOK_CB_FAILURE_TTL_MS=failure counter window in ms, default 300000
+WEBHOOK_CB_REQUEUE_DELAY_MS=delay (ms) used to requeue when circuit is open, default 300000
 WEBHOOK_SEND_NEW_MESSAGES=true, send new messages to webhook, caution with this, messages will be duplicated, default is false
 WEBHOOK_SEND_GROUP_MESSAGES=true, send group messages to webhook, default is true
 WEBHOOK_SEND_OUTGOING_MESSAGES=true, send outgoing messages to webhook, default is true
@@ -531,6 +532,7 @@ Circuit breaker behavior:
 - Counts consecutive webhook failures within `WEBHOOK_CB_FAILURE_TTL_MS`.
 - When the count reaches `WEBHOOK_CB_FAILURE_THRESHOLD`, the circuit opens for `WEBHOOK_CB_OPEN_MS` and sends are skipped.
 - After the open window, delivery is attempted again automatically.
+- When the circuit is open, the message is requeued with a longer delay (`WEBHOOK_CB_REQUEUE_DELAY_MS`) to avoid retry storms.
 
 Why keep `WEBHOOK_TIMEOUT_MS` low:
 - A high timeout blocks the consumer for too long when the endpoint is offline.
@@ -542,6 +544,7 @@ WEBHOOK_CB_ENABLED=true
 WEBHOOK_CB_FAILURE_THRESHOLD=1
 WEBHOOK_CB_FAILURE_TTL_MS=300000
 WEBHOOK_CB_OPEN_MS=120000
+WEBHOOK_CB_REQUEUE_DELAY_MS=300000
 WEBHOOK_TIMEOUT_MS=60000
 ```
 

--- a/README.md
+++ b/README.md
@@ -488,6 +488,10 @@ WEBHOOK_URL=the webhook url, this config attribute put phone number on the end, 
 WEBHOOK_TOKEN=the webhook header token
 WEBHOOK_HEADER=the webhook header name
 WEBHOOK_TIMEOUT_MS=webhook request timeout, default 5000 ms
+WEBHOOK_CB_ENABLED=true enable webhook circuit breaker to avoid backlog when endpoint is offline, default true
+WEBHOOK_CB_FAILURE_THRESHOLD=number of failures within window to open circuit, default 1
+WEBHOOK_CB_OPEN_MS=how long to keep the circuit open (skip sends), default 120000
+WEBHOOK_CB_FAILURE_TTL_MS=failure counter window in ms, default 300000
 WEBHOOK_SEND_NEW_MESSAGES=true, send new messages to webhook, caution with this, messages will be duplicated, default is false
 WEBHOOK_SEND_GROUP_MESSAGES=true, send group messages to webhook, default is true
 WEBHOOK_SEND_OUTGOING_MESSAGES=true, send outgoing messages to webhook, default is true
@@ -522,6 +526,13 @@ WEBHOOK_FORWARD_TOKEN=the token of whatsapp cloud api, default is empty
 WEBHOOK_FORWARD_VERSION=the version of whatsapp cloud api, default is v17.0
 WEBHOOK_FORWARD_URL=the url of whatsapp cloud api, default is https://graph.facebook.com
 WEBHOOK_FORWARD_TIMEOUT_MS=the timeout for request to whatsapp cloud api, default is 360000
+```
+Example (circuit breaker):
+```env
+WEBHOOK_CB_ENABLED=true
+WEBHOOK_CB_FAILURE_THRESHOLD=1
+WEBHOOK_CB_FAILURE_TTL_MS=300000
+WEBHOOK_CB_OPEN_MS=120000
 ```
 
 ### Config session with redis
@@ -809,3 +820,4 @@ Mail to sales@unoapi.cloud
 - Counting connection retry attempts even when restarting to prevent looping messages
 - Message delete endpoint
 - Send reply message with please to send again, when any error and message enqueue in .dead
+

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -65,6 +65,12 @@ export const WEBHOOK_ADD_TO_BLACKLIST_ON_OUTGOING_MESSAGE_WITH_TTL =
     ? undefined
     : parseInt(process.env.WEBHOOK_ADD_TO_BLACKLIST_ON_OUTGOING_MESSAGE_WITH_TTL!)
 export const WEBHOOK_SESSION = process.env.WEBHOOK_SESSION || ''
+// Webhook circuit breaker (fail fast when endpoints are offline)
+export const WEBHOOK_CB_ENABLED =
+  process.env.WEBHOOK_CB_ENABLED == _undefined ? true : process.env.WEBHOOK_CB_ENABLED == 'true'
+export const WEBHOOK_CB_FAILURE_THRESHOLD = parseInt(process.env.WEBHOOK_CB_FAILURE_THRESHOLD || '1')
+export const WEBHOOK_CB_OPEN_MS = parseInt(process.env.WEBHOOK_CB_OPEN_MS || '120000')
+export const WEBHOOK_CB_FAILURE_TTL_MS = parseInt(process.env.WEBHOOK_CB_FAILURE_TTL_MS || '300000')
 export const AMQP_URL = process.env.AMQP_URL || 'amqp://guest:guest@localhost:5672'
 export const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379'
 export const PROXY_URL = process.env.PROXY_URL

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -46,7 +46,7 @@ export const WEBHOOK_TIMEOUT_MS = parseInt(process.env.WEBHOOK_TIMEOUT_MS || '60
 export const FETCH_TIMEOUT_MS = parseInt(process.env.FETCH_TIMEOUT_MS || '60000')
 export const CONNECTION_TYPE = process.env.CONNECTION_TYPE || 'qrcode'
 
-export const CONSUMER_TIMEOUT_MS = parseInt(process.env.CONSUMER_TIMEOUT_MS || '360000')
+export const CONSUMER_TIMEOUT_MS = parseInt(process.env.CONSUMER_TIMEOUT_MS || '15000')
 export const WEBHOOK_SEND_NEW_MESSAGES = process.env.WEBHOOK_SEND_NEW_MESSAGES == _undefined ? false : process.env.WEBHOOK_SEND_NEW_MESSAGES == 'true'
 export const WEBHOOK_SEND_INCOMING_MESSAGES =
   process.env.WEBHOOK_SEND_INCOMING_MESSAGES == _undefined ? true : process.env.WEBHOOK_SEND_INCOMING_MESSAGES == 'true'

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -71,6 +71,7 @@ export const WEBHOOK_CB_ENABLED =
 export const WEBHOOK_CB_FAILURE_THRESHOLD = parseInt(process.env.WEBHOOK_CB_FAILURE_THRESHOLD || '1')
 export const WEBHOOK_CB_OPEN_MS = parseInt(process.env.WEBHOOK_CB_OPEN_MS || '120000')
 export const WEBHOOK_CB_FAILURE_TTL_MS = parseInt(process.env.WEBHOOK_CB_FAILURE_TTL_MS || '300000')
+export const WEBHOOK_CB_REQUEUE_DELAY_MS = parseInt(process.env.WEBHOOK_CB_REQUEUE_DELAY_MS || '300000')
 export const AMQP_URL = process.env.AMQP_URL || 'amqp://guest:guest@localhost:5672'
 export const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379'
 export const PROXY_URL = process.env.PROXY_URL

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -72,6 +72,7 @@ export const WEBHOOK_CB_FAILURE_THRESHOLD = parseInt(process.env.WEBHOOK_CB_FAIL
 export const WEBHOOK_CB_OPEN_MS = parseInt(process.env.WEBHOOK_CB_OPEN_MS || '120000')
 export const WEBHOOK_CB_FAILURE_TTL_MS = parseInt(process.env.WEBHOOK_CB_FAILURE_TTL_MS || '300000')
 export const WEBHOOK_CB_REQUEUE_DELAY_MS = parseInt(process.env.WEBHOOK_CB_REQUEUE_DELAY_MS || '300000')
+export const WEBHOOK_CB_LOCAL_CLEANUP_INTERVAL_MS = parseInt(process.env.WEBHOOK_CB_LOCAL_CLEANUP_INTERVAL_MS || '3600000')
 export const AMQP_URL = process.env.AMQP_URL || 'amqp://guest:guest@localhost:5672'
 export const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379'
 export const PROXY_URL = process.env.PROXY_URL

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -34,7 +34,7 @@ export const WEBHOOK_FORWARD_BUSINESS_ACCOUNT_ID = process.env.WEBHOOK_FORWARD_B
 export const WEBHOOK_FORWARD_TOKEN = process.env.WEBHOOK_FORWARD_TOKEN || ''
 export const WEBHOOK_FORWARD_VERSION = process.env.WEBHOOK_FORWARD_VERSION || 'v17.0'
 export const WEBHOOK_FORWARD_URL = process.env.WEBHOOK_FORWARD_URL || 'https://graph.facebook.com'
-export const WEBHOOK_FORWARD_TIMEOUT_MS = parseInt(process.env.WEBHOOK_TIMEOUT_MS || '360000')
+export const WEBHOOK_FORWARD_TIMEOUT_MS = parseInt(process.env.WEBHOOK_TIMEOUT_MS || '60000')
 
 // comunication
 export const UNOAPI_URL = process.env.UNOAPI_URL || 'http://localhost:9876'
@@ -42,8 +42,8 @@ export const WEBHOOK_URL_ABSOLUTE = process.env.WEBHOOK_URL_ABSOLUTE || ''
 export const WEBHOOK_URL = process.env.WEBHOOK_URL || 'http://localhost:9876/webhooks/fake'
 export const WEBHOOK_HEADER = process.env.WEBHOOK_HEADER || 'Authorization'
 export const WEBHOOK_TOKEN = process.env.WEBHOOK_TOKEN || UNOAPI_AUTH_TOKEN || '123abc'
-export const WEBHOOK_TIMEOUT_MS = parseInt(process.env.WEBHOOK_TIMEOUT_MS || '360000')
-export const FETCH_TIMEOUT_MS = parseInt(process.env.FETCH_TIMEOUT_MS || '360000')
+export const WEBHOOK_TIMEOUT_MS = parseInt(process.env.WEBHOOK_TIMEOUT_MS || '60000')
+export const FETCH_TIMEOUT_MS = parseInt(process.env.FETCH_TIMEOUT_MS || '60000')
 export const CONNECTION_TYPE = process.env.CONNECTION_TYPE || 'qrcode'
 
 export const CONSUMER_TIMEOUT_MS = parseInt(process.env.CONSUMER_TIMEOUT_MS || '360000')

--- a/src/services/outgoing_cloud_api.ts
+++ b/src/services/outgoing_cloud_api.ts
@@ -167,7 +167,10 @@ export class OutgoingCloudApi implements Outgoing {
         return false
       }
     } catch (e) {
-      logger.warn(e as any, 'WEBHOOK_CB failure handler error')
+      logger.warn(e as any, 'WEBHOOK_CB failure handler error (phone=%s webhook=%s)', phone, cbId)
+      try { logger.warn(error as any, 'WEBHOOK_CB original error (phone=%s webhook=%s)', phone, cbId) } catch {}
+      // If the CB handler fails, fall back to the original error path (no circuit open)
+      return false
     }
     try { logger.warn(error as any, 'WEBHOOK_CB send failed (phone=%s webhook=%s)', phone, cbId) } catch {}
     return false
@@ -224,3 +227,4 @@ const maybeCleanupLocalCircuit = (now: number) => {
     if (now >= st.exp) cbFailState.delete(key)
   }
 }
+

--- a/src/services/outgoing_cloud_api.ts
+++ b/src/services/outgoing_cloud_api.ts
@@ -45,13 +45,14 @@ export class OutgoingCloudApi implements Outgoing {
     const cbKey = `${phone}:${cbId}`
     const now = Date.now()
     if (cbEnabled) {
+      let open = false
       try {
-        const open = await isWebhookCircuitOpen(phone, cbId)
-        if (open) {
-          logger.warn('WEBHOOK_CB open: skipping send (phone=%s webhook=%s)', phone, cbId)
-          throw new WebhookCircuitOpenError(`WEBHOOK_CB open for ${cbId}`, this.cbRequeueDelayMs())
-        }
+        open = await isWebhookCircuitOpen(phone, cbId)
       } catch {}
+      if (open) {
+        logger.warn('WEBHOOK_CB open: skipping send (phone=%s webhook=%s)', phone, cbId)
+        throw new WebhookCircuitOpenError(`WEBHOOK_CB open for ${cbId}`, this.cbRequeueDelayMs())
+      }
       if (isCircuitOpenLocal(cbKey, now)) {
         logger.warn('WEBHOOK_CB open (local): skipping send (phone=%s webhook=%s)', phone, cbId)
         throw new WebhookCircuitOpenError(`WEBHOOK_CB open (local) for ${cbId}`, this.cbRequeueDelayMs())

--- a/src/services/outgoing_cloud_api.ts
+++ b/src/services/outgoing_cloud_api.ts
@@ -5,7 +5,7 @@ import logger from './logger'
 import { completeCloudApiWebHook, isGroupMessage, isOutgoingMessage, isNewsletterMessage, isUpdateMessage, extractDestinyPhone, extractFromPhone } from './transformer'
 import { addToBlacklist, isInBlacklist } from './blacklist'
 import { PublishOption } from '../amqp'
-import { WEBHOOK_CB_ENABLED, WEBHOOK_CB_FAILURE_THRESHOLD, WEBHOOK_CB_OPEN_MS, WEBHOOK_CB_FAILURE_TTL_MS, WEBHOOK_CB_REQUEUE_DELAY_MS } from '../defaults'
+import { WEBHOOK_CB_ENABLED, WEBHOOK_CB_FAILURE_THRESHOLD, WEBHOOK_CB_OPEN_MS, WEBHOOK_CB_FAILURE_TTL_MS, WEBHOOK_CB_REQUEUE_DELAY_MS, WEBHOOK_CB_LOCAL_CLEANUP_INTERVAL_MS } from '../defaults'
 import { isWebhookCircuitOpen, openWebhookCircuit, closeWebhookCircuit, bumpWebhookCircuitFailure } from './redis'
 
 class WebhookCircuitOpenError extends Error {
@@ -176,7 +176,7 @@ export class OutgoingCloudApi implements Outgoing {
 const cbOpenUntil: Map<string, number> = new Map()
 const cbFailState: Map<string, { count: number; exp: number }> = new Map()
 let cbLastCleanup = 0
-const CB_CLEANUP_INTERVAL_MS = 60 * 60 * 1000
+const CB_CLEANUP_INTERVAL_MS = WEBHOOK_CB_LOCAL_CLEANUP_INTERVAL_MS || 60 * 60 * 1000
 
 const isCircuitOpenLocal = (key: string, now: number) => {
   maybeCleanupLocalCircuit(now)

--- a/src/services/outgoing_cloud_api.ts
+++ b/src/services/outgoing_cloud_api.ts
@@ -5,6 +5,8 @@ import logger from './logger'
 import { completeCloudApiWebHook, isGroupMessage, isOutgoingMessage, isNewsletterMessage, isUpdateMessage, extractDestinyPhone, extractFromPhone } from './transformer'
 import { addToBlacklist, isInBlacklist } from './blacklist'
 import { PublishOption } from '../amqp'
+import { WEBHOOK_CB_ENABLED, WEBHOOK_CB_FAILURE_THRESHOLD, WEBHOOK_CB_OPEN_MS, WEBHOOK_CB_FAILURE_TTL_MS } from '../defaults'
+import { isWebhookCircuitOpen, openWebhookCircuit, closeWebhookCircuit, bumpWebhookCircuitFailure } from './redis'
 
 export class OutgoingCloudApi implements Outgoing {
   private getConfig: getConfig
@@ -29,6 +31,23 @@ export class OutgoingCloudApi implements Outgoing {
   }
 
   public async sendHttp(phone: string, webhook: Webhook, message: object, _options: Partial<PublishOption> = {}) {
+    const cbEnabled = !!WEBHOOK_CB_ENABLED && WEBHOOK_CB_FAILURE_THRESHOLD > 0 && WEBHOOK_CB_OPEN_MS > 0
+    const cbId = (webhook && (webhook.id || webhook.url || webhook.urlAbsolute)) ? `${webhook.id || webhook.url || webhook.urlAbsolute}` : 'default'
+    const cbKey = `${phone}:${cbId}`
+    const now = Date.now()
+    if (cbEnabled) {
+      try {
+        const open = await isWebhookCircuitOpen(phone, cbId)
+        if (open) {
+          logger.warn('WEBHOOK_CB open: skipping send (phone=%s webhook=%s)', phone, cbId)
+          return
+        }
+      } catch {}
+      if (isCircuitOpenLocal(cbKey, now)) {
+        logger.warn('WEBHOOK_CB open (local): skipping send (phone=%s webhook=%s)', phone, cbId)
+        return
+      }
+    }
     const destinyPhone = await this.isInBlacklist(phone, webhook.id, message)
     if (destinyPhone) {
       logger.info(`Session phone %s webhook %s and destiny phone %s are in blacklist`, phone, webhook.id, destinyPhone)
@@ -89,11 +108,81 @@ export class OutgoingCloudApi implements Outgoing {
     } catch (error) {
       logger.error('Error on send to url %s with headers %s and body %s', url, JSON.stringify(headers), body)
       logger.error(error)
+      if (cbEnabled) {
+        await this.handleCircuitFailure(phone, cbId, cbKey, error as any)
+        return
+      }
       throw error
     }
     logger.debug('Response: %s', response?.status)
     if (!response?.ok) {
-      throw await response?.text()
+      const errText = await response?.text()
+      if (cbEnabled) {
+        await this.handleCircuitFailure(phone, cbId, cbKey, errText)
+        return
+      }
+      throw errText
+    }
+    if (cbEnabled) {
+      try {
+        await closeWebhookCircuit(phone, cbId)
+      } catch {}
+      resetCircuitLocal(cbKey)
     }
   }
+
+  private async handleCircuitFailure(phone: string, cbId: string, cbKey: string, error: any) {
+    try {
+      const threshold = WEBHOOK_CB_FAILURE_THRESHOLD || 1
+      const openMs = WEBHOOK_CB_OPEN_MS || 120000
+      const ttlMs = WEBHOOK_CB_FAILURE_TTL_MS || openMs
+      const count = await bumpWebhookCircuitFailure(phone, cbId, ttlMs)
+      const localCount = bumpCircuitFailureLocal(cbKey, ttlMs)
+      const finalCount = Math.max(count || 0, localCount || 0)
+      if (finalCount >= threshold) {
+        await openWebhookCircuit(phone, cbId, openMs)
+        openCircuitLocal(cbKey, openMs)
+        logger.warn('WEBHOOK_CB opened (phone=%s webhook=%s count=%s openMs=%s)', phone, cbId, finalCount, openMs)
+      } else {
+        logger.warn('WEBHOOK_CB failure (phone=%s webhook=%s count=%s/%s)', phone, cbId, finalCount, threshold)
+      }
+    } catch (e) {
+      logger.warn(e as any, 'WEBHOOK_CB failure handler error')
+    }
+    try { logger.warn(error as any, 'WEBHOOK_CB send failed (phone=%s webhook=%s)', phone, cbId) } catch {}
+  }
+}
+
+const cbOpenUntil: Map<string, number> = new Map()
+const cbFailState: Map<string, { count: number; exp: number }> = new Map()
+
+const isCircuitOpenLocal = (key: string, now: number) => {
+  const until = cbOpenUntil.get(key)
+  if (!until) return false
+  if (now >= until) {
+    cbOpenUntil.delete(key)
+    return false
+  }
+  return true
+}
+
+const openCircuitLocal = (key: string, openMs: number) => {
+  cbOpenUntil.set(key, Date.now() + Math.max(1, openMs || 0))
+}
+
+const resetCircuitLocal = (key: string) => {
+  cbOpenUntil.delete(key)
+  cbFailState.delete(key)
+}
+
+const bumpCircuitFailureLocal = (key: string, ttlMs: number): number => {
+  const now = Date.now()
+  const ttl = Math.max(1, ttlMs || 0)
+  const current = cbFailState.get(key)
+  if (!current || now >= current.exp) {
+    cbFailState.set(key, { count: 1, exp: now + ttl })
+    return 1
+  }
+  current.count += 1
+  return current.count
 }


### PR DESCRIPTION
How the circuit breaker (CB) works in the webhook flow

Main flow

Each webhook send first checks whether the circuit is open.
If it is open, it does not attempt to send the webhook and throws WebhookCircuitOpenError so the consumer requeues with delay (avoids backlog and retry loops).
How the circuit opens

When a send fails (timeout, network error, or non‑OK HTTP response), the CB records a failure.
If the number of failures within the window (WEBHOOK_CB_FAILURE_TTL_MS) reaches the threshold (WEBHOOK_CB_FAILURE_THRESHOLD), the circuit opens for WEBHOOK_CB_OPEN_MS.
While open

Messages are not sent to the webhook.
The consumer requeues with delay (WEBHOOK_CB_REQUEUE_DELAY_MS), reducing pressure on the queue.
Where state is stored

Redis: primary, shared state across instances.
Local (in‑memory): fast fallback if Redis fails or as a cache, with periodic cleanup (WEBHOOK_CB_LOCAL_CLEANUP_INTERVAL_MS).
Why a lower timeout helps

A smaller WEBHOOK_TIMEOUT_MS makes errors surface faster → CB opens sooner → fewer messages stuck.

-------

Fluxo principal

Cada envio de webhook tenta primeiro verificar se o circuito está aberto.
Se estiver aberto, ele não tenta enviar o webhook e lança WebhookCircuitOpenError para o consumidor re-enfileirar com atraso (evita backlog e retry em loop).
Como abre o circuito

Quando um envio falha (timeout, erro de rede ou resposta HTTP não‑OK), o CB registra essa falha.
Se o número de falhas dentro da janela (WEBHOOK_CB_FAILURE_TTL_MS) atingir o limite (WEBHOOK_CB_FAILURE_THRESHOLD), o circuito abre por WEBHOOK_CB_OPEN_MS.
Enquanto aberto

As mensagens não são enviadas para o webhook.
O consumidor re-enfileira com delay (WEBHOOK_CB_REQUEUE_DELAY_MS), reduzindo pressão na fila.
Onde guarda estado

Redis: estado principal (compartilhado entre instâncias).
Local (memória): fallback rápido se Redis falhar ou como cache, com limpeza periódica (WEBHOOK_CB_LOCAL_CLEANUP_INTERVAL_MS).
Por que o timeout baixo ajuda

WEBHOOK_TIMEOUT_MS menor faz o erro aparecer rápido → CB abre mais cedo → menos mensagens travadas.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configurable webhook circuit breaker (thresholds, open window, failure TTL, requeue delay, local cleanup) and per-session behavior.
  * New webhook controls to fine‑tune which events/messages are forwarded.

* **Bug Fixes / Behavior**
  * Adjusted default timeouts for faster fail‑fast behavior and reduced backlog; retry/requeue delays now respect circuit‑open conditions.

* **Documentation**
  * README expanded with circuit breaker guidance, examples, and extended webhook/Redis configuration samples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->